### PR TITLE
Simplify versioning and publish workflow

### DIFF
--- a/.github/workflows/sdk-api-build.yml
+++ b/.github/workflows/sdk-api-build.yml
@@ -40,11 +40,19 @@ jobs:
       working-directory: tests/Enclave.Sdk.Api.Tests
       run: dotnet test -c Release
 
-    - name: Push Github Source Packages
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-      run: dotnet nuget push src/**/*${{ steps.gitversion.outputs.SemVer }}.nupkg  --api-key ${{github.token}} -s https://nuget.pkg.github.com/enclave-networks/index.json --skip-duplicate
+    - name: Push to GitHub Packages (PR - alpha)
+      if: github.event_name == 'pull_request'
+      run: dotnet nuget push src/**/*${{ steps.gitversion.outputs.SemVer }}.nupkg --api-key ${{github.token}} -s https://nuget.pkg.github.com/enclave-networks/index.json --skip-duplicate
 
-    - name: Push To nuget.org
+    - name: Push to GitHub Packages (develop - beta)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+      run: dotnet nuget push src/**/*${{ steps.gitversion.outputs.SemVer }}.nupkg --api-key ${{github.token}} -s https://nuget.pkg.github.com/enclave-networks/index.json --skip-duplicate
+
+    - name: Push to GitHub Packages (main - stable)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: dotnet nuget push src/**/*${{ steps.gitversion.outputs.SemVer }}.nupkg --api-key ${{github.token}} -s https://nuget.pkg.github.com/enclave-networks/index.json --skip-duplicate
+
+    - name: Push to nuget.org (main - stable)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: dotnet nuget push src/**/*${{ steps.gitversion.outputs.SemVer }}.nupkg -k ${{ secrets.PUBLIC_NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ dotnet test tests/Enclave.Sdk.Api.Tests --filter "FullyQualifiedName~DnsClientTe
 
 ## Architecture Overview
 
-This is a .NET 6 SDK for consuming the Enclave Management APIs. The SDK is published as a NuGet package.
+This is a .NET 10 SDK for consuming the Enclave Management APIs. The SDK is published as a NuGet package.
 
 ### Client Hierarchy
 
@@ -59,3 +59,10 @@ Tests use NUnit with WireMock.Net for HTTP mocking. Each client has a correspond
 - Private fields prefixed with underscore (`_fieldName`)
 - StyleCop analyzers enabled
 - Nullable reference types enabled
+
+## Versioning and Releases
+
+Versioning is handled by **GitVersion** (see `GitVersion.yml`). Merging to main triggers a release - no manual tagging required.
+
+- **GitHub Packages**: All builds (alpha/beta/stable) - for internal Enclave consumers
+- **nuget.org**: Stable releases only - for external third-party consumers

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,11 +1,15 @@
 assembly-versioning-scheme: None
 mode: ContinuousDelivery
 next-version: 1.0.0
+label: alpha
 branches:
   main:
-   mode: ContinuousDelivery
+    mode: ContinuousDeployment
+    label: ''
+    increment: Patch
   develop:
-   increment: Patch
+    label: beta
+    increment: Patch
 ignore:
   sha: []
 merge-message-formats: {}


### PR DESCRIPTION
- Update GitVersion.yml for v6 (tag → label)
- Use ContinuousDeployment on main for stable versions without manual tagging
- Publish all builds to GitHub Packages (alpha/beta/stable)
- Keep nuget.org for stable releases only
- Update CLAUDE.md with .NET 10 and release process